### PR TITLE
リリースビルドの設定を実施

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -1,0 +1,38 @@
+name: build pdf
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: build pdf and upload release
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+      - run: npm install
+      - name: build pdf
+        run: npm run build:pdf
+      - name: create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./docs/README.pdf
+          asset_name: resume.pdf
+          asset_content_type: application/pdf

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "lint": "textlint docs/README.md"
+    "lint": "textlint docs/README.md",
+    "build:pdf": "md-to-pdf docs/README.md --config-file ./pdf-configs/config.js"
   },
   "devDependencies": {
     "@proofdict/textlint-rule-proofdict": "^3.1.2",


### PR DESCRIPTION
## 概要

タグ付けでPDFをビルドできるようにする。

## 内容

- npm-scriptsの作成
- GitHub Actionsの設定

close #5 