### PR TITLE
GitHub Actionsのrunnerの変更を実施

### DIFF
--- a/.github/workflows/lint-text.yml
+++ b/.github/workflows/lint-text.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: lint text
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta


### PR DESCRIPTION
## 概要

textlintを行うGitHub Actionsのrunnerだけ18.04だったため、22.04に統一。

## 内容

- textlintのrunnerをubuntu 22.04に変更

close #10 